### PR TITLE
feat: implement cbor based representation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "prepare": "tsc --build",
     "test:web": "playwright-test test/**/*.spec.js --cov && nyc report",
-    "test:node": "c8 --check-coverage mocha test/**/*.spec.js",
-    "test:node:coverage": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/**/*.spec.js",
+    "test:node": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/**/*.spec.js",
     "test": "mocha test/**/*.spec.js",
     "coverage": "c8 --reporter=html mocha test/test-*.js && npm_config_yes=true npx st -d coverage -p 8080",
     "typecheck": "tsc --build"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@ipld/dag-cbor": "^7.0.1",
+    "@ipld/dag-json": "^8.0.9",
     "multiformats": "^9.6.4"
   },
   "type": "module",
@@ -58,7 +59,7 @@
     "@types/mocha": "^9.1.0",
     "@web-std/fetch": "^4.0.0",
     "@web-std/file": "^3.0.2",
-    "ucans": "https://github.com/ucan-wg/ts-ucan.git",
+    "ucans": "^0.9.0",
     "c8": "^7.11.0",
     "chai": "^4.3.6",
     "mocha": "^9.2.0",

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -1,4 +1,0 @@
-import * as UCAN from "./ucan.js"
-import * as json from "multiformats/codecs/json"
-import * as CBOR from "@ipld/dag-cbor"
-import { view } from "./view.js"

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1,0 +1,83 @@
+import * as UCAN from "./ucan.js"
+import * as json from "@ipld/dag-json"
+import { base64urlpad } from "multiformats/bases/base64"
+
+/**
+ * @template {UCAN.Capability} C
+ * @param {UCAN.Data<C>} data
+ */
+export const format = ({ header, body, signature }) =>
+  `${formatHeader(header)}.${formatBody(body)}.${formatSignature(signature)}`
+
+/**
+ * @template {UCAN.Capability} C
+ * @param {object} payload
+ * @param {UCAN.Header} payload.header
+ * @param {UCAN.Body<C>} payload.body
+ */
+export const formatPayload = ({ header, body }) =>
+  `${formatHeader(header)}.${formatBody(body)}`
+
+/**
+ * @param {UCAN.Header} header
+ */
+export const formatHeader = header =>
+  base64urlpad.baseEncode(encodeHeader(header))
+
+/**
+ * @param {UCAN.Body} body
+ */
+export const formatBody = body => base64urlpad.baseEncode(encodeBody(body))
+
+/**
+ * @template {UCAN.Capability} C
+ * @param {UCAN.Signature<[UCAN.Header, UCAN.Body<C>]>} signature
+ */
+export const formatSignature = signature => base64urlpad.baseEncode(signature)
+
+/**
+ * @param {UCAN.Header} header
+ */
+export const encodeHeader = header =>
+  json.encode({
+    alg: encodeAgorithm(header.algorithm),
+    ucv: header.version,
+    typ: "JWT",
+  })
+
+/**
+ * @param {UCAN.Body} body
+ */
+export const encodeBody = body =>
+  json.encode({
+    iss: body.issuer,
+    aud: body.audience,
+    att: body.capabilities,
+    exp: body.expiration,
+    prf: body.proofs.map(encodeProof),
+    ...(body.facts.length > 0 && { fct: body.facts }),
+    ...(body.nonce && { nnc: body.nonce }),
+    ...(body.notBefore && { nbf: body.notBefore }),
+  })
+
+/**
+ * @param {UCAN.Proof} proof
+ * @returns {string}
+ */
+export const encodeProof = proof => proof.toString()
+
+/**
+ * @template {number} Code
+ * @param {Code} code
+ */
+export const encodeAgorithm = code => {
+  switch (code) {
+    case 0xed:
+      return "EdDSA"
+    case 0x1205:
+      return "RS256"
+    /* c8 ignore next 2 */
+    default:
+      throw new RangeError(`Unknown KeyType "${code}"`)
+  }
+}

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,298 @@
+import * as UCAN from "./ucan.js"
+import * as UTF8 from "./utf8.js"
+import { base64urlpad } from "multiformats/bases/base64"
+import * as json from "@ipld/dag-json"
+import { CID } from "multiformats"
+import { identity } from "multiformats/hashes/identity"
+import * as raw from "multiformats/codecs/raw"
+
+/**
+ * Parse JWT formatted UCAN. Note than no validation takes place here.
+ *
+ * @template {UCAN.Capability} C
+ * @param {UCAN.JWT<UCAN.Data<C>>} input
+ * @returns {UCAN.Data<C>}
+ */
+export const parse = input => {
+  const segments = input.split(".")
+  const [header, body, signature] =
+    segments.length === 3
+      ? segments
+      : ParseError.throw(
+          `Can't parse UCAN: ${input}: Expected JWT format: 3 dot-separated base64url-encoded values.`
+        )
+
+  return {
+    header: parseHeader(header),
+    body: parseBody(body),
+    signature: base64urlpad.baseDecode(signature),
+  }
+}
+
+/**
+ * @param {string} header
+ * @returns {UCAN.Header}
+ */
+export const parseHeader = header => {
+  const { ucv, alg, typ } = json.decode(base64urlpad.baseDecode(header))
+
+  const _type = parseJWT(typ)
+
+  return {
+    version: parseUCV(ucv),
+    algorithm: parseAlgorithm(alg),
+  }
+}
+
+/**
+ * @template {UCAN.Capability} C
+ * @param {string} input
+ * @returns {UCAN.Body<C>}
+ */
+export const parseBody = input => {
+  const body = json.decode(base64urlpad.baseDecode(input))
+
+  return {
+    issuer: parseDID(body.iss),
+    audience: parseDID(body.aud),
+    expiration: parseInt(body.exp, 10),
+    nonce: parseOptionalString(body.nnc, "nnc"),
+    notBefore: parseMaybeInt(body.nbf, "nbf"),
+    facts: parseOptionalArray(body.fct, parseFact, "fct") || [],
+    proofs: parseProofs(body.prf),
+    capabilities: /** @type {C[]} */ (
+      parseArray(body.att, parseCapability, "att")
+    ),
+  }
+}
+
+/**
+ * @param {unknown} input
+ */
+
+const parseCapability = input => parseStruct(input, asCapability, "att")
+
+/**
+ * @template {UCAN.Capability} C
+ * @param {object & {can?:unknown, with?:unknown}|C} input
+ * @returns {C}
+ */
+export const asCapability = input => {
+  const capability = /** @type {C} */ ({
+    ...input,
+    can: parseAbility(input.can),
+    with: parseResource(input.with),
+  })
+  const resource = capability.with
+
+  // @see https://github.com/ucan-wg/spec/#422-action
+  if (
+    resource.endsWith("*") &&
+    capability.can !== "*" &&
+    (resource.startsWith("my:") || resource.startsWith("as:did:"))
+  ) {
+    return ParseError.throw(
+      `Capability has invalid 'can: ${JSON.stringify(
+        input.can
+      )}', for all 'my:*' or 'as:<did>:*' it must be '*'.`
+    )
+  }
+
+  return capability
+}
+
+/**
+ * @param {unknown} input
+ */
+const parseAbility = input =>
+  typeof input !== "string"
+    ? ParseError.throw(
+        `Capability has invalid 'can: ${JSON.stringify(
+          input
+        )}', value must be a string`
+      )
+    : input.slice(1, -1).includes("/")
+    ? /** @type {UCAN.Ability} */ (input.toLocaleLowerCase())
+    : input === "*"
+    ? input
+    : ParseError.throw(
+        `Capability has invalid 'can: "${input}"', value must have at least one path segment`
+      )
+
+/**
+ * @param {unknown} input
+ */
+const parseResource = input =>
+  typeof input !== "string"
+    ? ParseError.throw(
+        `Capability has invalid 'with: ${JSON.stringify(
+          input
+        )}', value must be a string`
+      )
+    : parseURL(input) ||
+      ParseError.throw(
+        `Capability has invalid 'with: "${input}"', value must be a valid URI string`
+      )
+
+/**
+ * @param {string} input
+ */
+const parseURL = input => {
+  try {
+    new URL(input)
+    return input
+  } catch (_) {
+    return null
+  }
+}
+/**
+ * @template T
+ * @param {unknown} input
+ * @param {(input:unknown) => T} parser
+ * @param {string} context
+ * @returns {T[]}
+ */
+const parseArray = (input, parser, context) =>
+  Array.isArray(input)
+    ? input.map(parser)
+    : ParseError.throw(`${context} must be an array`)
+
+/**
+ * @template T
+ * @param {unknown} input
+ * @param {(input:unknown) => T} parser
+ * @param {string} context
+ * @returns {T[]|undefined}
+ */
+const parseOptionalArray = (input, parser, context) =>
+  input === undefined ? input : parseArray(input, parser, context)
+
+/**
+ * @template T
+ * @param {unknown} input
+ * @param {(input:object) => T} parser
+ * @param {string} context
+ * @returns {T}
+ */
+const parseStruct = (input, parser, context) =>
+  input != null && typeof input === "object"
+    ? parser(input)
+    : ParseError.throw(`${context} must be of type object`)
+
+/**
+ * @param {unknown} input
+ * @returns {UCAN.Fact}
+ */
+const parseFact = input => parseStruct(input, Object, "fct elements")
+
+/**
+ * @param {unknown} input
+ */
+const parseProofs = input =>
+  Array.isArray(input)
+    ? parseArray(input, parseProof, "prf")
+    : [parseProof(input)]
+
+/**
+ * @param {unknown} input
+ * @returns {UCAN.Proof}
+ */
+const parseProof = input => {
+  const proof =
+    typeof input === "string"
+      ? input
+      : ParseError.throw(
+          `prf has invalid value ${JSON.stringify(input)}, must be a string`
+        )
+  try {
+    return /** @type {UCAN.Proof} */ (CID.parse(proof))
+  } catch (error) {
+    return /** @type {UCAN.Proof} */ (
+      CID.create(1, raw.code, identity.digest(UTF8.encode(proof)))
+    )
+  }
+}
+
+/**
+ * @param {unknown} input
+ * @returns {UCAN.DID}
+ */
+const parseDID = input =>
+  typeof input === "string" && input.startsWith("did:")
+    ? /** @type {UCAN.DID} */ (input)
+    : ParseError.throw(`DID has invalid representation '${input}'`)
+
+/**
+ * @param {unknown} input
+ * @param {string} [context]
+ */
+const parseOptionalString = (input, context = "Field") => {
+  switch (typeof input) {
+    case "string":
+    case "undefined":
+      return input
+    default:
+      return ParseError.throw(`${context} has invalid value ${input}`)
+  }
+}
+
+/**
+ * @param {unknown} input
+ * @param {string} [context]
+ */
+const parseMaybeInt = (input, context = "Field") => {
+  switch (typeof input) {
+    case "undefined":
+      return undefined
+    case "number":
+      return parseInt(/** @type {any} */ (input), 10)
+    default:
+      return ParseError.throw(
+        `${context} has invalid value ${JSON.stringify(input)}`
+      )
+  }
+}
+
+/**
+ * @param {unknown} input
+ * @returns {UCAN.Version}
+ */
+const parseUCV = input =>
+  /\d+\.\d+\.\d+/.test(/** @type {string} */ (input))
+    ? /** @type {UCAN.Version} */ (input)
+    : ParseError.throw(`Header has invalid version 'ucv: "${input}"'`)
+
+/**
+ * @param {unknown} input
+ * @returns {"JWT"}
+ */
+const parseJWT = input =>
+  input === "JWT"
+    ? input
+    : ParseError.throw(`Header has invalid type 'typ: "${input}"'`)
+
+/**
+ * @param {unknown} input
+ */
+const parseAlgorithm = input => {
+  switch (input) {
+    case "EdDSA":
+      return 0xed
+    case "RS256":
+      return 0x1205
+    default:
+      return ParseError.throw(
+        `Header has invalid algorithm 'alg: ${JSON.stringify(input)}'`
+      )
+  }
+}
+
+class ParseError extends TypeError {
+  /**
+   * @param {string} message
+   * @returns {never}
+   */
+  static throw(message) {
+    throw new this(message)
+  }
+}

--- a/src/ucan.js
+++ b/src/ucan.js
@@ -1,0 +1,2 @@
+// TODO: Send PR to multicodec table
+export const code = 0x78c0

--- a/src/view.js
+++ b/src/view.js
@@ -1,72 +1,63 @@
 import * as UCAN from "./ucan.js"
-import * as json from "multiformats/codecs/json"
-import { CID } from "multiformats/cid"
 
 /**
  * @template {UCAN.Capability} C
- * @param {UCAN.IR<C>} data
- * @returns {UCAN.UCAN<C>}
+ * @template {"IPLD"|"JWT"} Type
+ * @extends {View<C>}
  */
-
-export const view = data => new UCANView(data)
-
-/**
- * @template {UCAN.Capability} C
- * @implements {UCAN.IR<C>}
- * @implements {UCAN.View<C>}
- */
-class UCANView {
+class View {
   /**
-   * @param {UCAN.IR<C>} data
+   * @param {Type} type
+   * @param {UCAN.Data<C>} data
    */
-  constructor({ header, body, signature }) {
+  constructor(type, { header, body, signature }) {
+    /** @readonly */
+    this.type = type
+    /** @readonly */
     this.header = header
+    /** @readonly */
     this.body = body
+    /** @readonly */
     this.signature = signature
   }
 
   get version() {
-    const { version } = decodeHeader(this.header)
-    Object.defineProperties(this, {
-      version: { value: version },
-    })
-
-    return version
+    return this.header.version
+  }
+  get algorithm() {
+    return this.header.algorithm
   }
 
-  /**
-   * @returns {UCAN.DID}
-   */
   get issuer() {
-    return decode(this).issuer
+    return this.body.issuer
   }
 
   /**
    * @returns {UCAN.DID}
    */
   get audience() {
-    return decode(this).audience
+    return this.body.audience
   }
 
   /**
    * @returns {C[]}
    */
   get capabilities() {
-    return decode(this).capabilities
+    return this.body.capabilities
   }
 
   /**
    * @returns {number}
    */
   get expiration() {
-    return decode(this).expiration
+    return this.body.expiration
   }
 
   /**
    * @returns {undefined|number}
    */
   get notBefore() {
-    return decode(this).notBefore
+    return this.body.notBefore
   }
 
   /**
@@ -74,14 +65,14 @@ class UCANView {
    */
 
   get nonce() {
-    return decode(this).nonce
+    return this.body.nonce
   }
 
   /**
    * @returns {UCAN.Fact[]}
    */
   get facts() {
-    return decode(this).facts || []
+    return this.body.facts
   }
 
   /**
@@ -89,63 +80,37 @@ class UCANView {
    */
 
   get proofs() {
-    return decode(this).proofs
+    return this.body.proofs
   }
 }
 
 /**
  * @template {UCAN.Capability} C
- * @param {UCANView<C>} self
- * @returns {UCAN.View<C>}
+ * @extends {View<C, "JWT">}
  */
-const decode = self => {
-  const {
-    issuer,
-    audience,
-    capabilities,
-    expiration,
-    facts,
-    notBefore,
-    nonce,
-    proofs,
-  } = decodeBody(self.body)
-
-  return Object.defineProperties(self, {
-    issuer: { value: issuer },
-    audience: { value: audience },
-    capabilities: { value: capabilities },
-    expiration: { value: expiration },
-    facts: { value: facts },
-    notBefore: { value: notBefore },
-    nonce: { value: nonce },
-    proofs: { value: proofs },
-  })
-}
-
-/**
- * @param {UCAN.ByteView<UCAN.Header>} bytes
- * @returns {UCAN.Header}
- */
-const decodeHeader = bytes => {
-  const { alg, ucv } = json.decode(bytes)
-  return { algorithm: alg, version: ucv }
-}
-
-/**
- * @param {UCAN.ByteView<UCAN.Body>} bytes
- * @returns {UCAN.Body}
- */
-const decodeBody = bytes => {
-  const { iss, aud, att, exp, fct, nbpf, nnc, prf } = json.decode(bytes)
-
-  return {
-    issuer: iss,
-    audience: aud,
-    capabilities: att,
-    expiration: exp,
-    facts: fct,
-    notBefore: nbpf,
-    nonce: nnc,
-    proofs: prf.map(CID.parse),
+class JWTView extends View {
+  /**
+   *
+   * @param {UCAN.Data<C>} data
+   * @param {*} jwt
+   */
+  constructor(data, jwt) {
+    super("JWT", data)
+    this.jwt = jwt
   }
 }
+
+/**
+ * @template {UCAN.Capability} C
+ * @param {UCAN.Data<C>} data
+ * @returns {UCAN.View<C>}
+ */
+export const view = data => new View("IPLD", data)
+
+/**
+ * @template {UCAN.Capability} C
+ * @param {UCAN.Data<C>} data
+ * @param {UCAN.JWT<UCAN.Data<C>>} jwt
+ * @returns {UCAN.View<C>}
+ */
+export const jwt = (data, jwt) => new JWTView(data, jwt)

--- a/src/view.js
+++ b/src/view.js
@@ -76,7 +76,7 @@ class View {
   }
 
   /**
-   * @returns {UCAN.Link<UCAN.UCAN, 1, UCAN.code>[]}
+   * @returns {UCAN.Proof[]}
    */
 
   get proofs() {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,31 +1,21 @@
-import { EdKeypair } from "ucans"
-import * as UCAN from "../src/ucan.js"
-
-/**
- * @param {string} secret
- */
-const createIssuer = secret =>
-  /** @type {UCAN.Issuer & EdKeypair} */
-  (
-    Object.assign(EdKeypair.fromSecretKey(secret), {
-      algorithm: 0xed,
-    })
-  )
+import { createEdIssuer, createRSAIssuer } from "./util.js"
 
 /** did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi */
-export const alice = createIssuer(
+export const alice = createEdIssuer(
   "U+bzp2GaFQHso587iSFWPSeCzbSfn/CbNHEz7ilKRZ1UQMmMS7qq4UhTzKn3X9Nj/4xgrwa+UqhMOeo4Ki8JUw=="
 )
 
 /** did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob */
-export const bob = createIssuer(
+export const bob = createEdIssuer(
   "G4+QCX1b3a45IzQsQd4gFMMe0UB1UOx9bCsh8uOiKLER69eAvVXvc8P2yc4Iig42Bv7JD2zJxhyFALyTKBHipg=="
 )
 
 /** did:key:z6MktafZTREjJkvV5mfJxcLpNBoVPwDLhTuMg9ng7dY4zMAL */
-export const mallory = createIssuer(
+export const mallory = createEdIssuer(
   "LR9AL2MYkMARuvmV3MJV8sKvbSOdBtpggFCW8K62oZDR6UViSXdSV/dDcD8S9xVjS61vh62JITx7qmLgfQUSZQ=="
 )
+
+export const service = createRSAIssuer()
 
 /**
  * @param {string} did

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -1,17 +1,18 @@
 /* eslint-env mocha */
 import * as UCAN from "../src/lib.js"
 import { assert } from "chai"
-import { fetch } from "./util.js"
 import { alice, bob, mallory } from "./fixtures.js"
-import * as token from "ucans/dist/token.js"
-
-const utf8 = new TextEncoder()
-const MURMUR = 0x22
-
-/**
- * @param {string} text
- */
-const utf8Encode = text => utf8.encode(text)
+import * as TSUCAN from "./ts-ucan.cjs"
+import * as raw from "multiformats/codecs/raw"
+import * as UTF8 from "../src/utf8.js"
+import { identity } from "multiformats/hashes/identity"
+import {
+  createRSAIssuer,
+  assertCompatible,
+  assertUCAN,
+  buildJWT,
+  formatUnsafe,
+} from "./util.js"
 
 describe("dag-ucan", () => {
   it("self-issued token", async () => {
@@ -26,19 +27,223 @@ describe("dag-ucan", () => {
       ],
     })
 
-    assert.deepEqual(ucan.issuer, alice.did())
-    assert.deepEqual(ucan.audience, alice.did())
-    assert.deepEqual(ucan.capabilities, [
-      {
-        with: alice.did(),
-        can: "store/put",
-      },
-    ])
+    assertUCAN(ucan, {
+      type: "IPLD",
+      version: UCAN.VERSION,
+      algorithm: alice.algorithm,
+      issuer: alice.did(),
+      audience: alice.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+      notBefore: undefined,
+      nonce: undefined,
+      facts: [],
+      proofs: [],
+    })
+
     assert.ok(ucan.expiration > Date.now() / 1000)
-    assert.equal(ucan.notBefore, undefined)
-    assert.equal(ucan.nonce, undefined)
-    assert.equal(ucan.facts, undefined)
-    assert.deepEqual(ucan.proofs, [])
+  })
+
+  it("dervie token", async () => {
+    const root = await UCAN.issue({
+      issuer: alice,
+      audience: bob.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+    })
+    const proof = await UCAN.link(root)
+
+    const leaf = await UCAN.issue({
+      issuer: bob,
+      audience: mallory.did(),
+      capabilities: root.capabilities,
+      expiration: root.expiration,
+      proofs: [proof],
+    })
+
+    assertUCAN(leaf, {
+      type: "IPLD",
+      version: UCAN.VERSION,
+      algorithm: alice.algorithm,
+      issuer: bob.did(),
+      audience: mallory.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+      notBefore: undefined,
+      nonce: undefined,
+      facts: [],
+      proofs: [proof],
+    })
+  })
+
+  it("rsa did", async () => {
+    const bot = await createRSAIssuer()
+
+    const root = await UCAN.issue({
+      issuer: alice,
+      audience: bot.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+    })
+    const proof = await UCAN.link(root)
+
+    const leaf = await UCAN.issue({
+      issuer: bot,
+      audience: bob.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+      proofs: [proof],
+    })
+
+    assertUCAN(leaf, {
+      type: "IPLD",
+      version: UCAN.VERSION,
+      algorithm: bot.algorithm,
+      issuer: bot.did(),
+      audience: bob.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+      notBefore: undefined,
+      nonce: undefined,
+      facts: [],
+      proofs: [proof],
+    })
+
+    await assertCompatible(leaf)
+  })
+
+  it("with nonce", async () => {
+    const root = await UCAN.issue({
+      issuer: alice,
+      audience: bob.did(),
+      nonce: "hello",
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+    })
+
+    await assertCompatible(root)
+    assertUCAN(root, {
+      type: "IPLD",
+      version: UCAN.VERSION,
+      algorithm: alice.algorithm,
+      issuer: alice.did(),
+      audience: bob.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+      notBefore: undefined,
+      nonce: "hello",
+      facts: [],
+      proofs: [],
+    })
+  })
+
+  it("with facts", async () => {
+    const root = await UCAN.issue({
+      issuer: alice,
+      audience: bob.did(),
+      facts: [
+        {
+          hello: "world",
+        },
+      ],
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+    })
+
+    await assertCompatible(root)
+    assertUCAN(root, {
+      type: "IPLD",
+      version: UCAN.VERSION,
+      algorithm: alice.algorithm,
+      issuer: alice.did(),
+      audience: bob.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+      facts: [
+        {
+          hello: "world",
+        },
+      ],
+      notBefore: undefined,
+      nonce: undefined,
+      proofs: [],
+    })
+  })
+
+  it("with notBefore", async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const root = await UCAN.issue({
+      issuer: alice,
+      audience: bob.did(),
+      facts: [],
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+      notBefore: now + 10,
+      expiration: now + 120,
+    })
+
+    assertUCAN(root, {
+      type: "IPLD",
+      version: UCAN.VERSION,
+      algorithm: alice.algorithm,
+      issuer: alice.did(),
+      audience: bob.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+      facts: [],
+      notBefore: now + 10,
+      expiration: now + 120,
+      nonce: undefined,
+      proofs: [],
+    })
   })
 
   it("ts-ucan compat", async () => {
@@ -54,7 +259,7 @@ describe("dag-ucan", () => {
     })
 
     assert.ok(
-      await token.validate(UCAN.format(ucan), {
+      await TSUCAN.validate(UCAN.format(ucan), {
         checkIsExpired: true,
         checkIssuer: true,
         checkSignature: true,
@@ -63,57 +268,410 @@ describe("dag-ucan", () => {
   })
 })
 
-describe("ts-ucan compat", () => {
-  async function makeUcan() {
-    return await token.build({
-      audience: bob.did(),
-      issuer: alice,
-      capabilities: [
-        {
-          with: {
-            scheme: "wnfs",
-            hierPart: "//boris.fission.name/public/photos/",
+describe("errors", () => {
+  it("throws on bad audience", async () => {
+    try {
+      const root = await UCAN.issue({
+        issuer: alice,
+        // @ts-expect-error
+        audience: "bob",
+        nonce: "hello",
+        capabilities: [
+          {
+            with: alice.did(),
+            can: "store/put",
           },
-          can: { namespace: "crud", segments: ["DELETE"] },
-        },
-        {
-          with: {
-            scheme: "wnfs",
-            hierPart:
-              "//boris.fission.name/private/84MZ7aqwKn7sNiMGsSbaxsEa6EPnQLoKYbXByxNBrCEr",
-          },
-          can: { namespace: "wnfs", segments: ["APPEND"] },
-        },
-        {
-          with: { scheme: "mailto", hierPart: "boris@fission.codes" },
-          can: { namespace: "msg", segments: ["SEND"] },
-        },
-      ],
-    })
+        ],
+      })
+      assert.fail("Should have thrown on bad did")
+    } catch (error) {
+      assert.match(String(error), /The audience must be a DID/)
+    }
+  })
+
+  /** @type {Record<string, [UCAN.Capability, ?RegExp]>} */
+  const invilidCapabilities = {
+    'must have "can"': [
+      // @ts-expect-error
+      { with: alice.did() },
+      /Capability has invalid 'can: undefined', value must be a string/,
+    ],
+    "must have path segment": [
+      // @ts-expect-error
+      { with: alice.did(), can: "send" },
+      /Capability has invalid 'can: "send"', value must have at least one path segment/,
+    ],
+    "must have segment after path": [
+      { with: alice.did(), can: "send/" },
+      /Capability has invalid 'can: "send\/"', value must have at least one path segment/,
+    ],
+    "must have segment before path": [
+      { with: alice.did(), can: "/send" },
+      /Capability has invalid 'can: "\/send"', value must have at least one path segment/,
+    ],
+    "with my:* it must have can: *": [
+      {
+        with: "my:*",
+        can: "msg/send",
+      },
+      /Capability has invalid 'can: "msg\/send"', for all 'my:\*' or 'as:<did>:\*' it must be '\*'/,
+    ],
+    "with as:<did>:* must have can: *": [
+      {
+        // @ts-ignore
+        with: `as:${alice.did()}:*`,
+        can: "msg/send",
+      },
+      /Capability has invalid 'can: "msg\/send"', for all 'my:\*' or 'as:<did>:\*' it must be '\*'/,
+    ],
+
+    "with must be string": [
+      // @ts-expect-error
+      {
+        can: "msg/send",
+      },
+      /Capability has invalid 'with: undefined', value must be a string/,
+    ],
+
+    "with must have something prior to :": [
+      {
+        can: "msg/send",
+        with: ":hello",
+      },
+      /Capability has invalid 'with: ":hello"', value must be a valid URI string/,
+    ],
+
+    "with as:<did>:* may have can: *": [
+      {
+        // @ts-ignore
+        with: `as:${alice.did()}:*`,
+        can: "*",
+      },
+      null,
+    ],
+
+    "with my:* it may have can: *": [
+      {
+        with: "my:*",
+        can: "*",
+      },
+      null,
+    ],
   }
 
-  it("round-trips with token.build", async () => {
-    const ucan = await makeUcan()
+  for (const [title, [capability, expect]] of Object.entries(
+    invilidCapabilities
+  )) {
+    it(title, async () => {
+      try {
+        await UCAN.issue({
+          issuer: alice,
+          audience: bob.did(),
+          capabilities: [capability],
+        })
 
-    const ucan2 = UCAN.parse(token.encode(ucan))
-    assert.equal(ucan2.issuer, alice.did())
-    assert.equal(ucan2.audience, bob.did())
-    /*
-    For some reason ts-ucan encodes differently
-    assert.deepEqual(ucan2.capabilities, [
-      {
-        with: "wnfs://boris.fission.name/public/photos/",
-        can: "crud/DELETE",
+        if (expect) {
+          assert.fail("Should throw error on invalid capability")
+        }
+      } catch (error) {
+        if (expect) {
+          assert.match(String(error), expect)
+        } else {
+          throw error
+        }
+      }
+    })
+  }
+})
+
+describe("parse", () => {
+  it("errors on invalid jwt", async () => {
+    const jwt = await buildJWT({ issuer: alice, audience: bob })
+    assert.throws(
+      () => UCAN.parse(jwt.slice(jwt.indexOf(".") + 1)),
+      /Expected JWT format: 3 dot-separated/
+    )
+  })
+
+  it("hash conistent ucan is parsed into IPLD representation", async () => {
+    const jwt = await formatUnsafe(alice, {
+      body: {
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
       },
-      {
-        with: "wnfs://boris.fission.name/private/84MZ7aqwKn7sNiMGsSbaxsEa6EPnQLoKYbXByxNBrCEr",
-        can: "wnfs/APPEND",
+    })
+    const ucan = UCAN.parse(jwt)
+    assertUCAN(ucan, {
+      type: "IPLD",
+      version: UCAN.VERSION,
+      algorithm: alice.algorithm,
+      issuer: alice.did(),
+      audience: alice.did(),
+      capabilities: [
+        {
+          can: "send/message",
+          with: "mailto:*",
+        },
+      ],
+      facts: [],
+      notBefore: undefined,
+      nonce: undefined,
+      proofs: [],
+    })
+  })
+
+  it("errors on invalid nnc", async () => {
+    const jwt = await formatUnsafe(alice, {
+      body: {
+        nnc: 5,
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
       },
-      {
-        with: "mailto:boris@fission.codes",
-        can: "msg/SEND",
+    })
+
+    assert.throws(() => UCAN.parse(jwt), /nnc has invalid value 5/)
+  })
+
+  it("errors on invalid nbf", async () => {
+    const jwt = await formatUnsafe(alice, {
+      body: {
+        nbf: "tomorrow",
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
       },
-    ])
-    */
+    })
+
+    assert.throws(() => UCAN.parse(jwt), /nbf has invalid value "tomorrow"/)
+  })
+
+  it("errors on invalid alg", async () => {
+    const jwt = await formatUnsafe(alice, {
+      header: {
+        alg: alice.keyType,
+      },
+      body: {
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
+      },
+    })
+
+    assert.throws(
+      () => UCAN.parse(jwt),
+      /Header has invalid algorithm 'alg: "ed25519"'/
+    )
+  })
+
+  it("errors on invalid typ", async () => {
+    const jwt = await formatUnsafe(alice, {
+      header: {
+        typ: "IPLD",
+      },
+      body: {
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
+      },
+    })
+
+    assert.throws(
+      () => UCAN.parse(jwt),
+      /Header has invalid type 'typ: "IPLD"'/
+    )
+  })
+
+  it("errors on invalid ucv", async () => {
+    const jwt = await formatUnsafe(alice, {
+      header: {
+        ucv: "9.0",
+      },
+      body: {
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
+      },
+    })
+
+    assert.throws(
+      () => UCAN.parse(jwt),
+      /Header has invalid version 'ucv: "9.0"'/
+    )
+  })
+
+  it("errors on invalid att", async () => {
+    const jwt = await formatUnsafe(alice, {
+      body: {
+        att: {
+          can: "send/message",
+          with: "mailto:*",
+        },
+      },
+    })
+
+    assert.throws(() => UCAN.parse(jwt), /att must be an array/)
+  })
+
+  it("errors on invalid fct", async () => {
+    const jwt = await formatUnsafe(alice, {
+      body: {
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
+        fct: [1],
+      },
+    })
+
+    assert.throws(() => UCAN.parse(jwt), /fct elements must be of type object/)
+  })
+
+  it("errors on invalid aud", async () => {
+    const jwt = await formatUnsafe(alice, {
+      body: {
+        aud: "bob",
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
+        fct: [1],
+      },
+    })
+
+    assert.throws(() => UCAN.parse(jwt), /DID has invalid representation 'bob'/)
+  })
+
+  it("errors on invalid prf (must be array of string)", async () => {
+    const jwt = await formatUnsafe(alice, {
+      body: {
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
+        prf: [1],
+      },
+    })
+
+    assert.throws(
+      () => UCAN.parse(jwt),
+      /prf has invalid value 1, must be a string/
+    )
+  })
+
+  it("errors on invalid prf", async () => {
+    const jwt = await formatUnsafe(alice, {
+      body: {
+        att: [
+          {
+            can: "send/message",
+            with: "mailto:*",
+          },
+        ],
+        prf: {},
+      },
+    })
+
+    assert.throws(
+      () => UCAN.parse(jwt),
+      /prf has invalid value {}, must be a string/
+    )
+  })
+})
+
+describe("ts-ucan compat", () => {
+  it("round-trips with token.build", async () => {
+    const jwt = await buildJWT({ issuer: alice, audience: bob })
+    const ucan = UCAN.parse(jwt)
+    assertUCAN(ucan, {
+      type: "JWT",
+      version: UCAN.VERSION,
+      issuer: alice.did(),
+      audience: bob.did(),
+      facts: [],
+      proofs: [],
+      notBefore: undefined,
+      nonce: undefined,
+      capabilities: [
+        {
+          with: "wnfs://boris.fission.name/public/photos/",
+          can: "crud/delete",
+        },
+        {
+          with: "wnfs://boris.fission.name/private/84MZ7aqwKn7sNiMGsSbaxsEa6EPnQLoKYbXByxNBrCEr",
+          can: "wnfs/append",
+        },
+        { with: "mailto:boris@fission.codes", can: "msg/send" },
+      ],
+    })
+
+    assert.equal(UCAN.format(ucan), jwt)
+  })
+
+  it("can have inline proofs", async () => {
+    const root = await buildJWT({
+      issuer: alice,
+      audience: bob,
+    })
+
+    const leaf = await buildJWT({
+      issuer: bob,
+      audience: mallory,
+      proofs: [root],
+    })
+
+    const ucan = UCAN.parse(leaf)
+    assertUCAN(ucan, {
+      type: "JWT",
+      version: UCAN.VERSION,
+      issuer: bob.did(),
+      audience: mallory.did(),
+      facts: [],
+      notBefore: undefined,
+      nonce: undefined,
+      capabilities: [
+        {
+          with: "wnfs://boris.fission.name/public/photos/",
+          can: "crud/delete",
+        },
+        {
+          with: "wnfs://boris.fission.name/private/84MZ7aqwKn7sNiMGsSbaxsEa6EPnQLoKYbXByxNBrCEr",
+          can: "wnfs/append",
+        },
+        { with: "mailto:boris@fission.codes", can: "msg/send" },
+      ],
+    })
+
+    const [proof] = ucan.proofs
+
+    assert.equal(proof.code, raw.code)
+    assert.equal(proof.multihash.code, identity.code)
+
+    assert.equal(UTF8.decode(proof.multihash.digest), root)
   })
 })

--- a/test/ts-ucan.cjs
+++ b/test/ts-ucan.cjs
@@ -1,0 +1,14 @@
+// works around https://github.com/ucan-wg/ts-ucan/issues/71
+
+const lib = require("ucans")
+exports.lib = lib
+
+const { validate, build, encode, EdKeypair, RsaKeypair, parse, capability } =
+  lib
+exports.EdKeypair = lib.EdKeypair
+exports.RsaKeypair = lib.RsaKeypair
+exports.validate = validate
+exports.build = build
+exports.encode = encode
+exports.parse = parse
+exports.capability = capability

--- a/test/util.js
+++ b/test/util.js
@@ -1,64 +1,148 @@
-import { File } from "@web-std/file"
-import { CID } from "multiformats"
-import fetch from "@web-std/fetch"
-import { sha256 } from "multiformats/hashes/sha2"
-
-const utf8Encoder = new TextEncoder()
-
-/**
- * @param {string} input
- */
-export const encodeUTF8 = input => utf8Encoder.encode(input)
+import * as UCAN from "../src/lib.js"
+import * as TSUCAN from "./ts-ucan.cjs"
+import { assert } from "chai"
+import { base64urlpad } from "multiformats/bases/base64"
+import * as json from "@ipld/dag-json"
+import * as UTF8 from "../src/utf8.js"
 
 /**
- * Utility function to generate deterministic garbage by hashing seed input,
- * then recursively hashing the product until total number of bytes yield
- * reaches `byteLength` (by default it is inifinity).
- *
- * @param {object} [options]
- * @param {Uint8Array} [options.seed]
- * @param {number} [options.byteLength]
+ * @param {UCAN.UCAN} ucan
  */
-export async function* hashrecur({
-  seed = encodeUTF8("hello world"),
-  byteLength = Infinity,
-} = {}) {
-  let value = seed
-  let byteOffset = 0
-  while (true) {
-    value = await sha256.encode(value)
-    const size = byteLength - byteOffset
-    if (size < value.byteLength) {
-      yield value.slice(0, size)
-      break
-    } else {
-      byteOffset += value.byteLength
-      yield value
-    }
+export const toTSUCAN = ucan => {
+  const jwt = UCAN.format(ucan)
+  return TSUCAN.parse(jwt)
+}
+
+/**
+ * @param {UCAN.UCAN} ucan
+ */
+export const assertCompatible = ucan =>
+  TSUCAN.validate(UCAN.format(ucan), {
+    checkIsExpired: true,
+    checkIssuer: true,
+    checkSignature: true,
+  })
+
+/**
+ * @param {UCAN.View} actual
+ * @param {Partial<UCAN.View>} expect
+ */
+export const assertUCAN = (actual, expect) => {
+  assertUCANIncludes(actual, expect)
+  assertUCANIncludes(UCAN.parse(UCAN.format(actual)), expect)
+  assertUCANIncludes(UCAN.decode(UCAN.encode(actual)), expect)
+}
+/**
+ * @param {UCAN.View} actual
+ * @param {Partial<UCAN.View>} expect
+ */
+export const assertUCANIncludes = (actual, expect) => {
+  for (const [key, value] of Object.entries(expect)) {
+    const name = /** @type {keyof UCAN.View} */ (key)
+    assert.deepEqual(actual[name], value, key)
   }
 }
 
 /**
- * @param {string|URL} target
- * @param {AsyncIterable<Uint8Array>} content
- * @returns {Promise<void>}
+ * @param {UCAN.View} actual
  */
-export const writeFile = async (target, content) => {
-  const fs = "fs"
-  const { createWriteStream } = await import(fs)
-  const file = createWriteStream(target)
-  for await (const chunk of content) {
-    file.write(chunk)
-  }
+export const assertFormatLoop = actual => {
+  assert.deepEqual(UCAN.parse(UCAN.format(actual)), actual)
+}
 
-  return await new Promise((resolve, reject) =>
-    file.close(
-      /**
-       * @param {unknown} error
-       */
-      error => (error ? reject(error) : resolve(undefined))
-    )
+/**
+ * @param {UCAN.View} actual
+ */
+export const assertCodecLoop = actual => {
+  assert.deepEqual(UCAN.decode(UCAN.encode(actual)), actual)
+}
+
+/**
+ * @param {string} secret
+ */
+export const createEdIssuer = secret =>
+  /** @type {UCAN.Issuer & TSUCAN.EdKeypair} */
+  (
+    Object.assign(TSUCAN.EdKeypair.fromSecretKey(secret), {
+      algorithm: 0xed,
+    })
   )
-}
 
-export { File, CID, fetch }
+export const createRSAIssuer = async () =>
+  /** @type {UCAN.Issuer & TSUCAN.RsaKeypair} */
+  (
+    Object.assign(await TSUCAN.RsaKeypair.create(), {
+      algorithm: 0x1205,
+    })
+  )
+
+/**
+ *
+ * @typedef {{
+ * issuer: TSUCAN.EdKeypair
+ * audience: UCAN.Audience
+ * proofs?: string[]
+ * }} BuildOptions
+ *
+ * @param {BuildOptions} options
+ */
+export const buildUCAN = async ({ issuer, audience, proofs }) =>
+  TSUCAN.build({
+    issuer,
+    audience: audience.did(),
+    capabilities: [
+      {
+        with: {
+          scheme: "wnfs",
+          hierPart: "//boris.fission.name/public/photos/",
+        },
+        can: { namespace: "crud", segments: ["DELETE"] },
+      },
+      {
+        with: {
+          scheme: "wnfs",
+          hierPart:
+            "//boris.fission.name/private/84MZ7aqwKn7sNiMGsSbaxsEa6EPnQLoKYbXByxNBrCEr",
+        },
+        can: { namespace: "wnfs", segments: ["APPEND"] },
+      },
+      {
+        with: { scheme: "mailto", hierPart: "boris@fission.codes" },
+        can: { namespace: "msg", segments: ["SEND"] },
+      },
+    ],
+    proofs,
+  })
+
+/**
+ * @param {BuildOptions} options
+ */
+export const buildJWT = async options => TSUCAN.encode(await buildUCAN(options))
+
+/**
+ * @param {UCAN.Issuer} issuer
+ * @param {{header?:object, body:object}} token
+ */
+export const formatUnsafe = async (issuer, token) => {
+  const header = base64urlpad.baseEncode(
+    json.encode({
+      typ: "JWT",
+      alg: "EdDSA",
+      ucv: "0.8.1",
+      ...token.header,
+    })
+  )
+  const body = base64urlpad.baseEncode(
+    json.encode({
+      iss: issuer.did(),
+      aud: issuer.did(),
+      exp: Math.floor(Date.now() / 1000) + 30,
+      prf: [],
+      att: [],
+
+      ...token.body,
+    })
+  )
+  const signature = await issuer.sign(UTF8.encode(`${header}.${body}`))
+  return `${header}.${body}.${base64urlpad.baseEncode(signature)}`
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,6 +210,14 @@
     cborg "^1.6.0"
     multiformats "^9.5.4"
 
+"@ipld/dag-json@^8.0.9":
+  version "8.0.9"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-json/-/dag-json-8.0.9.tgz#c41641ddbd3799abd0c683015c56a37f3f6d1edc"
+  integrity sha512-NNKHmgHxc2zOEaB8qOUpAb2UK1vcEE/rBeh018Da/RzXE7N8GwiTJLRZ3Fe/G4fsiis67G0sagRz/YNQcANRsQ==
+  dependencies:
+    cborg "^1.5.4"
+    multiformats "^9.5.4"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -625,7 +633,7 @@ caniuse-lite@^1.0.30001317:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz#2b4ad19b77aa36f61f2eaf72e636d7481d55e606"
   integrity sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==
 
-cborg@^1.6.0:
+cborg@^1.5.4, cborg@^1.6.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/cborg/-/cborg-1.9.0.tgz#4fa8bb8e31277afc479c2dc328e67d831d9b4369"
   integrity sha512-V55F9PB2rQHXcmkZKiUEE+4IhOHu9clfO5fpcVNpSPb5V0ZdPoKhgiGA0w26J5Pd93FiMXW47ovZMw3T8V1eWA==
@@ -2795,9 +2803,10 @@ typescript@^4.6.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
-"ucans@https://github.com/ucan-wg/ts-ucan.git":
-  version "0.8.0"
-  resolved "https://github.com/ucan-wg/ts-ucan.git#1a7d814755e510b20c4a961b76c1e2fea470f207"
+ucans@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/ucans/-/ucans-0.9.0.tgz#ddff51af15830503835033084a38e93da4d182b7"
+  integrity sha512-xl9jeO8mK9+JjheOCzKjwb7KAkXLnG3fpTPXQebUaMkJ6l+ovBLaZGhL/Gd4r5IuDWjW12qqwfp7FeBzbLINuQ==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     one-webcrypto "^1.0.1"


### PR DESCRIPTION
This changes representation of the UCAN (which was neither proper CBOR nor JWT) to a dual representation:

### IPLD representation

- IPLD representation is just that CBOR encoding of all the UCAN fields 
- Which normalizes capability "can" fields which are case insensitive for hash consistency
- It is default representation, all UCANs created by this library is in that representation
- Every IPLD UCAN is valid UCAN, but not every valid UCAN is IPLD UCAN. In nutshell, IPLD UCAN adds additional constraints for hash consistency
- In IPLD representation `proofs` are actual IPLD links (as opposed to stringified CIDs) 

### JWT representation

To support legacy UCANs or ones created by others library also supports JWT representation, which is basically raw bytes of JWT.

- When UCAN is parsed from JWT string, it is formatted with DAG-JSON (for hash consistency key order etc..) if formatted string comes out the same. UCAN returned is of 'IPLD' type (CBOR representation) otherwise it is of (JWT) type. That way formatting it back will produces valid JWT.
- When encoding JWT type UCAN it is just encoded same as RAW block.
- When decoding UCANs we first try CBOR decoder and if that fails fallback to parse, that way JWT type UCAN is decoded correctly. Perf of JWT type decode is not great, however it's just for backwards compatibility and probably fine.
  - Alternatively we could create new code for JWT type tokens, but that would require separate codec etc.. and does not seem worth it.
 
