### PR TITLE
feat: use code field in place of type as a new discriminant

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An implementation of [UCAN][]s representation in [IPLD][], designed for use with
 
 ## Overview
 
-This library implements multicodec for represenating [UCAN]s natively in [IPLD][]. It uses [DAG-CBOR][] as a primary encoding, which is more compact and has a better hash consitency than a secondary _RAW_ JWT encoding. Every UCAN in primary encoding can be formatted into a JWT string and consumed by spec compliant [UCAN][] implementations. However not every [UCAN][] can be encoded in a primary CBOR representation, as loss of whitespaces and key order would lead to mismatched signature. For this reasons library issues UCANs only in primary CBOR representation, however when parsing UCANs it will use secondary _RAW_ representation when primary representation can not be used, so it can interop with all existing tokens in the wild.
+This library implements multicodec for represenating [UCAN]s natively in [IPLD][]. It uses [DAG-CBOR][] as a primary encoding, which is more compact and has a better hash consitency than a secondary RAW JWT encoding. Every UCAN in primary encoding can be formatted into a JWT string and consumed by spec compliant [UCAN][] implementations. However not every [UCAN][] can be encoded in a primary CBOR representation, as loss of whitespaces and key order would lead to mismatched signature. Library issues UCANs only in primary CBOR representation. When parsing UCANs that can not have valid CBOR representation, secondary RAW representation is used, which allows interop with all existing tokens in the wild.
 
 ### Primary Representation
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # @ipld/dag-ucan
 
-An implementation of [UCAN][]s with [IPLD][] representation, designed to be used with [multiformats][].
+An implementation of [UCAN][]s representation in [IPLD][], designed for use with [multiformats][].
 
 ## Overview
 
-This library implements multicodec for represenating [UCAN]s natively in [IPLD][]. It uses [DAG-CBOR][] encoding as a primary representation, which is more compact and has better hash consitency than secondary representation which is raw bytes of JWT. Every UCAN in primary representation can be formatted as JWT and used by any spec compliant [UCAN][] implementation, however not every [UCAN][] can be represented by primary representation _(loss of whitespaces and key order would lead to different signatures)_. Such [UCAN][]s are parsed into a secondary "JWT" representation, which allows interop with all existing tokens in the wild.
+This library implements multicodec for represenating [UCAN]s natively in [IPLD][]. It uses [DAG-CBOR][] as a primary encoding, which is more compact and has a better hash consitency than a secondary _RAW_ JWT encoding. Every UCAN in primary encoding can be formatted into a JWT string and consumed by spec compliant [UCAN][] implementations. However not every [UCAN][] can be encoded in a primary CBOR representation, as loss of whitespaces and key order would lead to mismatched signature. For this reasons library issues UCANs only in primary CBOR representation, however when parsing UCANs it will use secondary _RAW_ representation when primary representation can not be used, so it can interop with all existing tokens in the wild.
 
 ### Primary Representation
 
@@ -64,7 +64,7 @@ import * as UCAN from "@ipld/dag-ucan"
 
 #### `UCAN.parse(jwt: string): UCAN.UCAN`
 
-Parses UCAN JWT string and returns `UCAN` object which can be encoded, formatted or queried.
+Parses UCAN formatted as JWT string into a representatino that can be encoded, formatted and queried.
 
 ```ts
 const ucan = UCAN.parse(jwt)
@@ -73,7 +73,7 @@ ucan.issuer // did:key:zAlice
 
 #### `UCAN.format(ucan: UCAN.UCAN): string`
 
-Formats UCAN as a JWT string.
+Formats UCAN into a JWT string.
 
 ```ts
 UCAN.format(UCAN.parse(jwt)) === jwt // true
@@ -81,15 +81,15 @@ UCAN.format(UCAN.parse(jwt)) === jwt // true
 
 #### `UCAN.encode(ucan: UCAN.UCAN): Uint8Array`
 
-Encodes UCAN into binary representation.
+Encodes UCAN into a binary representation.
 
 #### `UCAN.decode(bytes: Uint8Array): UCAN.UCAN`
 
-Decodes UCAN in binary representation into object representation.
+Decodes byte encoded UCAN.
 
 #### `UCAN.issue(options: UCAN.UCANOptions): Promise<UCAN.UCAN>`
 
-Issues or derives a UCAN. Returns promise for UCAN in IPLD representation.
+Issues or derives a UCAN.
 
 > Please note that no capability or time bound validation takes place
 

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -5,6 +5,7 @@ import { base64urlpad } from "multiformats/bases/base64"
 /**
  * @template {UCAN.Capability} C
  * @param {UCAN.Data<C>} data
+ * @returns {UCAN.JWT<UCAN.CBOR<C>>}
  */
 export const format = ({ header, body, signature }) =>
   `${formatHeader(header)}.${formatBody(body)}.${formatSignature(signature)}`
@@ -14,18 +15,21 @@ export const format = ({ header, body, signature }) =>
  * @param {object} payload
  * @param {UCAN.Header} payload.header
  * @param {UCAN.Body<C>} payload.body
+ * @returns {`${UCAN.Header}.${UCAN.Body}`}
  */
 export const formatPayload = ({ header, body }) =>
   `${formatHeader(header)}.${formatBody(body)}`
 
 /**
  * @param {UCAN.Header} header
+ * @returns {`${UCAN.Header}`}
  */
 export const formatHeader = header =>
   base64urlpad.baseEncode(encodeHeader(header))
 
 /**
  * @param {UCAN.Body} body
+ * @returns {`${UCAN.Body}`}
  */
 export const formatBody = body => base64urlpad.baseEncode(encodeBody(body))
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -95,7 +95,9 @@ export const decode = bytes => {
  */
 export const link = async (ucan, { hasher = sha256 } = {}) => {
   const digest = await hasher.digest(encode(ucan))
-  return /** @type {UCAN.Proof<C>} */ (CID.createV1(ucan.code, digest))
+  return /** @type {UCAN.Proof<C>} */ (
+    CID.createV1(ucan.code === raw ? raw : code, digest)
+  )
 }
 
 /**

--- a/src/lib.js
+++ b/src/lib.js
@@ -15,7 +15,6 @@ import { code } from "./ucan.js"
 export const VERSION = "0.8.1"
 
 export const raw = RAW.code
-export const cbor = CBOR.code
 
 /**
  * Encodes given UCAN (in either IPLD or JWT representation) and encodes it into
@@ -28,7 +27,7 @@ export const cbor = CBOR.code
  */
 export const encode = ucan => {
   switch (ucan.code) {
-    case cbor:
+    case code:
       return CBOR.encode({
         header: {
           version: ucan.header.version,
@@ -57,9 +56,9 @@ export const encode = ucan => {
 /**
  * @param {never} ucan
  */
-const invalidCode = ({ code }) => {
+const invalidCode = ({ code: unknown }) => {
   throw new TypeError(
-    `Provided UCAN has unsupported code: ${code}, it must be ${cbor} for CBOR representation or ${raw} for JWT representation`
+    `Provided UCAN has unsupported code: ${unknown}, it must be ${code} for CBOR representation or ${raw} for JWT representation`
   )
 }
 
@@ -136,7 +135,7 @@ export const parse = input => {
  */
 export const format = ucan => {
   switch (ucan.code) {
-    case cbor:
+    case code:
       return Formatter.format(ucan)
     case raw:
       return ucan.jwt

--- a/src/lib.js
+++ b/src/lib.js
@@ -6,7 +6,7 @@ import * as Parser from "./parser.js"
 import * as Formatter from "./formatter.js"
 import { sha256 } from "multiformats/hashes/sha2"
 import { CID } from "multiformats/cid"
-import raw from "multiformats/codecs/raw"
+import * as RAW from "multiformats/codecs/raw"
 
 export * from "./ucan.js"
 import { code } from "./ucan.js"
@@ -78,7 +78,7 @@ export const decode = bytes => {
 export const link = async (ucan, { hasher = sha256 } = {}) => {
   const digest = await hasher.digest(encode(ucan))
   return /** @type {UCAN.Proof<C>} */ (
-    CID.createV1(ucan.type === "IPLD" ? code : raw.code, digest)
+    CID.createV1(ucan.type === "IPLD" ? code : RAW.code, digest)
   )
 }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -6,6 +6,7 @@ import * as Parser from "./parser.js"
 import * as Formatter from "./formatter.js"
 import { sha256 } from "multiformats/hashes/sha2"
 import { CID } from "multiformats/cid"
+import raw from "multiformats/codecs/raw"
 
 export * from "./ucan.js"
 import { code } from "./ucan.js"
@@ -14,6 +15,10 @@ import { code } from "./ucan.js"
 export const VERSION = "0.8.1"
 
 /**
+ * Encodes given UCAN (in either IPLD or JWT representation) and encodes it into
+ * corresponding bytes representation. UCAN in IPLD representation is encoded as
+ * DAG-CBOR which JWT representation is encoded as raw bytes of JWT string.
+ *
  * @template {UCAN.Capability} C
  * @param {UCAN.UCAN<C>} data
  * @returns {UCAN.ByteView<UCAN.UCAN<C>>}
@@ -41,6 +46,11 @@ export const encode = data =>
     : UTF8.encode(data.jwt)
 
 /**
+ * Decodes binary encoded UCAN. It assumes UCAN is in primary IPLD
+ * representation and attempts to decode it with DAG-CBOR, if that
+ * fails it falls back to secondary representation and parses it as
+ * a JWT.
+ *
  * @template {UCAN.Capability} C
  * @param {UCAN.ByteView<UCAN.UCAN<C>>} bytes
  * @returns {UCAN.View<C>}
@@ -56,18 +66,33 @@ export const decode = bytes => {
 }
 
 /**
+ * Convenience function to create a CID for the given UCAN. If UCAN is
+ * in JWT represetation get CID with RAW multicodec, while UCANs in IPLD
+ * representation get UCAN multicodec code.
+ *
  * @template {UCAN.Capability} C
  * @param {UCAN.UCAN<C>} ucan
  * @param {{hasher?: UCAN.MultihashHasher}} [options]
- * @returns {Promise<UCAN.Link<UCAN.Data<C>, 1, typeof code>>}
+ * @returns {Promise<UCAN.Proof<C>>}
  */
 export const link = async (ucan, { hasher = sha256 } = {}) => {
   const digest = await hasher.digest(encode(ucan))
-  return /** @type {any} */ (CID.createV1(code, digest))
+  return /** @type {UCAN.Proof<C>} */ (
+    CID.createV1(ucan.type === "IPLD" ? code : raw.code, digest)
+  )
 }
 
 /**
- * Parse JWT formatted UCAN. Note than no validation takes place here.
+ * Parses UCAN formatted as JWT string. Returns UCAN view in IPLD representation
+ * when serailazing it back would produce original string, oherwise returns UCAN
+ * view in secondary JWT representation which is not as compact, but it retains
+ * key order and whitespaces so it could be formatted back to same JWT string.
+ * View will have `type` field with either `"IPLD"` or `"JWT"` value telling
+ * in which representation UCAN is.
+ *
+ * Note: Parsing does not perform validation of capabilities or semantics of the
+ * UCAN, it only ensures structure is spec compliant and throws `ParseError`
+ * if it is not.
  *
  * @template {UCAN.Capability} C
  * @param {UCAN.JWT<UCAN.Data<C>>} input
@@ -83,6 +108,8 @@ export const parse = input => {
 }
 
 /**
+ * Takes UCAN object and formats it into JWT string.
+ *
  * @template {UCAN.Capability} C
  * @param {UCAN.UCAN<C>} ucan
  * @returns {UCAN.JWT<UCAN.Data<C>>}
@@ -96,6 +123,10 @@ export const format = ucan => {
 }
 
 /**
+ * Creates a new signed token with a given `options.issuer`. If expiration is
+ * not set it defaults to 30 seconds from now. Returns UCAN in primary - IPLD
+ * representation.
+ *
  * @template {number} A
  * @template {UCAN.Capability} C
  * @param {UCAN.UCANOptions<C, A>} options

--- a/src/parser.js
+++ b/src/parser.js
@@ -10,7 +10,7 @@ import * as raw from "multiformats/codecs/raw"
  * Parse JWT formatted UCAN. Note than no validation takes place here.
  *
  * @template {UCAN.Capability} C
- * @param {UCAN.JWT<UCAN.Data<C>>} input
+ * @param {UCAN.JWT<UCAN.UCAN<C>>} input
  * @returns {UCAN.Data<C>}
  */
 export const parse = input => {

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -3,7 +3,8 @@ import type {
   MultihashHasher,
 } from "multiformats/hashes/interface"
 import type { MultibaseEncoder } from "multiformats/bases/interface"
-import type * as RAW from "multiformats/codecs/raw"
+import type { code as RAW_CODE } from "multiformats/codecs/raw"
+import type { code as CBOR_CODE } from "@ipld/dag-cbor"
 import type { Signer, Signature } from "./crypto.js"
 
 export * from "./crypto.js"
@@ -41,20 +42,20 @@ export interface Body<C extends Capability = Capability> {
 }
 export type JWT<T> = ToString<T>
 
-export type UCAN<C extends Capability = Capability> = IPLDUCAN<C> | JWTUCAN<C>
+export type UCAN<C extends Capability = Capability> = CBOR<C> | RAW<C>
 
 export interface Data<C extends Capability = Capability> {
   readonly header: Header
   readonly body: Body<C>
   readonly signature: Signature<[Header, Body<C>]>
 }
-export interface IPLDUCAN<C extends Capability = Capability> extends Data<C> {
-  readonly type: "IPLD"
+export interface CBOR<C extends Capability = Capability> extends Data<C> {
+  readonly code: typeof CBOR_CODE
 }
 
-export interface JWTUCAN<C extends Capability = Capability> {
-  type: "JWT"
-  jwt: JWT<Data<C>>
+export interface RAW<C extends Capability = Capability> {
+  readonly code: typeof RAW_CODE
+  readonly jwt: JWT<RAW<C>>
 }
 
 export type View<C extends Capability = Capability> = UCAN<C> &
@@ -81,7 +82,7 @@ export interface UCANOptions<
 
 export type Proof<C extends Capability = Capability> =
   | Link<Data<C>, 1, typeof code>
-  | Link<JWT<Data<C>>, 1, typeof RAW.code>
+  | Link<JWT<Data<C>>, 1, typeof RAW_CODE>
 
 export type Ability = `${string}/${string}` | "*"
 export type Resource = `${string}:${string}`

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -4,7 +4,6 @@ import type {
 } from "multiformats/hashes/interface"
 import type { MultibaseEncoder } from "multiformats/bases/interface"
 import type { code as RAW_CODE } from "multiformats/codecs/raw"
-import type { code as CBOR_CODE } from "@ipld/dag-cbor"
 import type { Signer, Signature } from "./crypto.js"
 
 export * from "./crypto.js"
@@ -50,7 +49,7 @@ export interface Data<C extends Capability = Capability> {
   readonly signature: Signature<[Header, Body<C>]>
 }
 export interface CBOR<C extends Capability = Capability> extends Data<C> {
-  readonly code: typeof CBOR_CODE
+  readonly code: typeof code
 }
 
 export interface RAW<C extends Capability = Capability> {

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -3,7 +3,7 @@ import type {
   MultihashHasher,
 } from "multiformats/hashes/interface"
 import type { MultibaseEncoder } from "multiformats/bases/interface"
-import type { sha256 } from "multiformats/hashes/sha2"
+import type * as RAW from "multiformats/codecs/raw"
 import type { Signer, Signature } from "./crypto.js"
 
 export * from "./crypto.js"
@@ -79,11 +79,9 @@ export interface UCANOptions<
   proofs?: Array<Proof>
 }
 
-export type Proof<C extends Capability = Capability> = Link<
-  Data<C>,
-  1,
-  typeof code
->
+export type Proof<C extends Capability = Capability> =
+  | Link<Data<C>, 1, typeof code>
+  | Link<JWT<Data<C>>, 1, typeof RAW.code>
 
 export type Ability = `${string}/${string}` | "*"
 export type Resource = `${string}:${string}`

--- a/src/view.js
+++ b/src/view.js
@@ -1,18 +1,20 @@
 import * as UCAN from "./ucan.js"
+import { code as CBOR_CODE } from "@ipld/dag-cbor"
+import { code as RAW_CODE } from "multiformats/codecs/raw"
 
 /**
  * @template {UCAN.Capability} C
- * @template {"IPLD"|"JWT"} Type
+ * @template {typeof CBOR_CODE|typeof RAW_CODE} Code
  * @extends {View<C>}
  */
 class View {
   /**
-   * @param {Type} type
+   * @param {Code} code
    * @param {UCAN.Data<C>} data
    */
-  constructor(type, { header, body, signature }) {
+  constructor(code, { header, body, signature }) {
     /** @readonly */
-    this.type = type
+    this.code = code
     /** @readonly */
     this.header = header
     /** @readonly */
@@ -86,16 +88,16 @@ class View {
 
 /**
  * @template {UCAN.Capability} C
- * @extends {View<C, "JWT">}
+ * @extends {View<C, typeof RAW_CODE>}
  */
-class JWTView extends View {
+class RAWView extends View {
   /**
    *
    * @param {UCAN.Data<C>} data
-   * @param {*} jwt
+   * @param {UCAN.JWT<UCAN.RAW<C>>} jwt
    */
   constructor(data, jwt) {
-    super("JWT", data)
+    super(RAW_CODE, data)
     this.jwt = jwt
   }
 }
@@ -105,12 +107,12 @@ class JWTView extends View {
  * @param {UCAN.Data<C>} data
  * @returns {UCAN.View<C>}
  */
-export const view = data => new View("IPLD", data)
+export const cbor = data => new View(CBOR_CODE, data)
 
 /**
  * @template {UCAN.Capability} C
  * @param {UCAN.Data<C>} data
- * @param {UCAN.JWT<UCAN.Data<C>>} jwt
+ * @param {UCAN.JWT<UCAN.RAW<C>>} jwt
  * @returns {UCAN.View<C>}
  */
-export const jwt = (data, jwt) => new JWTView(data, jwt)
+export const jwt = (data, jwt) => new RAWView(data, jwt)

--- a/src/view.js
+++ b/src/view.js
@@ -1,10 +1,9 @@
 import * as UCAN from "./ucan.js"
-import { code as CBOR_CODE } from "@ipld/dag-cbor"
-import { code as RAW_CODE } from "multiformats/codecs/raw"
+import * as RAW from "multiformats/codecs/raw"
 
 /**
  * @template {UCAN.Capability} C
- * @template {typeof CBOR_CODE|typeof RAW_CODE} Code
+ * @template {typeof UCAN.code|typeof RAW.code} Code
  * @extends {View<C>}
  */
 class View {
@@ -88,7 +87,7 @@ class View {
 
 /**
  * @template {UCAN.Capability} C
- * @extends {View<C, typeof RAW_CODE>}
+ * @extends {View<C, typeof RAW.code>}
  */
 class RAWView extends View {
   /**
@@ -97,7 +96,7 @@ class RAWView extends View {
    * @param {UCAN.JWT<UCAN.RAW<C>>} jwt
    */
   constructor(data, jwt) {
-    super(RAW_CODE, data)
+    super(RAW.code, data)
     this.jwt = jwt
   }
 }
@@ -107,7 +106,7 @@ class RAWView extends View {
  * @param {UCAN.Data<C>} data
  * @returns {UCAN.View<C>}
  */
-export const cbor = data => new View(CBOR_CODE, data)
+export const cbor = data => new View(UCAN.code, data)
 
 /**
  * @template {UCAN.Capability} C

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -28,7 +28,7 @@ describe("dag-ucan", () => {
     })
 
     assertUCAN(ucan, {
-      code: UCAN.cbor,
+      code: UCAN.code,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -71,7 +71,7 @@ describe("dag-ucan", () => {
     })
 
     assertUCAN(leaf, {
-      code: UCAN.cbor,
+      code: UCAN.code,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: bob.did(),
@@ -117,7 +117,7 @@ describe("dag-ucan", () => {
     })
 
     assertUCAN(leaf, {
-      code: UCAN.cbor,
+      code: UCAN.code,
       version: UCAN.VERSION,
       algorithm: bot.algorithm,
       issuer: bot.did(),
@@ -152,7 +152,7 @@ describe("dag-ucan", () => {
 
     await assertCompatible(root)
     assertUCAN(root, {
-      code: UCAN.cbor,
+      code: UCAN.code,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -189,7 +189,7 @@ describe("dag-ucan", () => {
 
     await assertCompatible(root)
     assertUCAN(root, {
-      code: UCAN.cbor,
+      code: UCAN.code,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -228,7 +228,7 @@ describe("dag-ucan", () => {
     })
 
     assertUCAN(root, {
-      code: UCAN.cbor,
+      code: UCAN.code,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -453,7 +453,7 @@ describe("parse", () => {
     })
     const ucan = UCAN.parse(jwt)
     assertUCAN(ucan, {
-      code: UCAN.cbor,
+      code: UCAN.code,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -60,6 +60,7 @@ describe("dag-ucan", () => {
       ],
     })
     const proof = await UCAN.link(root)
+    assert.equal(proof.code, UCAN.code)
 
     const leaf = await UCAN.issue({
       issuer: bob,

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -3,7 +3,7 @@ import * as UCAN from "../src/lib.js"
 import { assert } from "chai"
 import { alice, bob, mallory } from "./fixtures.js"
 import * as TSUCAN from "./ts-ucan.cjs"
-import * as raw from "multiformats/codecs/raw"
+import * as RAW from "multiformats/codecs/raw"
 import * as UTF8 from "../src/utf8.js"
 import { identity } from "multiformats/hashes/identity"
 import {
@@ -631,6 +631,9 @@ describe("ts-ucan compat", () => {
     })
 
     assert.equal(UCAN.format(ucan), jwt)
+
+    const cid = await UCAN.link(ucan)
+    assert.equal(cid.code, RAW.code)
   })
 
   it("can have inline proofs", async () => {
@@ -669,7 +672,7 @@ describe("ts-ucan compat", () => {
 
     const [proof] = ucan.proofs
 
-    assert.equal(proof.code, raw.code)
+    assert.equal(proof.code, RAW.code)
     assert.equal(proof.multihash.code, identity.code)
 
     assert.equal(UTF8.decode(proof.multihash.digest), root)

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -28,7 +28,7 @@ describe("dag-ucan", () => {
     })
 
     assertUCAN(ucan, {
-      type: "IPLD",
+      code: UCAN.cbor,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -70,7 +70,7 @@ describe("dag-ucan", () => {
     })
 
     assertUCAN(leaf, {
-      type: "IPLD",
+      code: UCAN.cbor,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: bob.did(),
@@ -116,7 +116,7 @@ describe("dag-ucan", () => {
     })
 
     assertUCAN(leaf, {
-      type: "IPLD",
+      code: UCAN.cbor,
       version: UCAN.VERSION,
       algorithm: bot.algorithm,
       issuer: bot.did(),
@@ -151,7 +151,7 @@ describe("dag-ucan", () => {
 
     await assertCompatible(root)
     assertUCAN(root, {
-      type: "IPLD",
+      code: UCAN.cbor,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -188,7 +188,7 @@ describe("dag-ucan", () => {
 
     await assertCompatible(root)
     assertUCAN(root, {
-      type: "IPLD",
+      code: UCAN.cbor,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -227,7 +227,7 @@ describe("dag-ucan", () => {
     })
 
     assertUCAN(root, {
-      type: "IPLD",
+      code: UCAN.cbor,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -382,6 +382,52 @@ describe("errors", () => {
       }
     })
   }
+
+  it("decode throws on invalid code", async () => {
+    const ucan = await UCAN.issue({
+      issuer: alice,
+      audience: bob.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+    })
+
+    assert.throws(
+      () =>
+        UCAN.encode({
+          ...ucan,
+          // @ts-expect-error
+          code: 0x0129,
+        }),
+      /Provided UCAN has unsupported code/
+    )
+  })
+
+  it("format throws on invalid code", async () => {
+    const ucan = await UCAN.issue({
+      issuer: alice,
+      audience: bob.did(),
+      capabilities: [
+        {
+          with: alice.did(),
+          can: "store/put",
+        },
+      ],
+    })
+
+    assert.throws(
+      () =>
+        UCAN.format({
+          ...ucan,
+          // @ts-expect-error
+          code: 0x0129,
+        }),
+      /Provided UCAN has unsupported code/
+    )
+  })
 })
 
 describe("parse", () => {
@@ -406,7 +452,7 @@ describe("parse", () => {
     })
     const ucan = UCAN.parse(jwt)
     assertUCAN(ucan, {
-      type: "IPLD",
+      code: UCAN.cbor,
       version: UCAN.VERSION,
       algorithm: alice.algorithm,
       issuer: alice.did(),
@@ -609,7 +655,7 @@ describe("ts-ucan compat", () => {
     const jwt = await buildJWT({ issuer: alice, audience: bob })
     const ucan = UCAN.parse(jwt)
     assertUCAN(ucan, {
-      type: "JWT",
+      code: UCAN.raw,
       version: UCAN.VERSION,
       issuer: alice.did(),
       audience: bob.did(),
@@ -650,7 +696,7 @@ describe("ts-ucan compat", () => {
 
     const ucan = UCAN.parse(leaf)
     assertUCAN(ucan, {
-      type: "JWT",
+      code: UCAN.raw,
       version: UCAN.VERSION,
       issuer: bob.did(),
       audience: mallory.did(),


### PR DESCRIPTION
Use of `code` in correspondence to representation makes more sense that original `type` field. This pull request replaces `type` with `code`.