### PR TITLE
feat: implement write API

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -91,13 +91,28 @@ export const decode = bytes => {
  * @template {UCAN.Capability} C
  * @param {UCAN.UCAN<C>} ucan
  * @param {{hasher?: UCAN.MultihashHasher}} [options]
- * @returns {Promise<UCAN.Proof<C>>}
  */
-export const link = async (ucan, { hasher = sha256 } = {}) => {
-  const digest = await hasher.digest(encode(ucan))
-  return /** @type {UCAN.Proof<C>} */ (
-    CID.createV1(ucan.code === raw ? raw : code, digest)
+export const link = async (ucan, options) => {
+  const { cid } = await write(ucan, options)
+  return cid
+}
+
+/**
+ * @template {UCAN.Capability} C
+ * @template {UCAN.UCAN<C>} Data
+ * @template {number} [A=typeof sha256.code]
+ * @param {Data} ucan
+ * @param {{hasher?: UCAN.MultihashHasher<A>}} [options]
+ */
+export const write = async (
+  ucan,
+  { hasher = /** @type {UCAN.MultihashHasher<any> } */ (sha256) } = {}
+) => {
+  const bytes = encode(ucan)
+  const cid = /** @type {CID & UCAN.Link<Data, 1, Data['code'], A>} */ (
+    CID.createV1(ucan.code, await hasher.digest(bytes))
   )
+  return { cid, bytes }
 }
 
 /**

--- a/src/lib.js
+++ b/src/lib.js
@@ -13,7 +13,7 @@ import { code } from "./ucan.js"
 
 /** @type {UCAN.Version} */
 export const VERSION = "0.8.1"
-export const name = 'dag-ucan'
+export const name = "dag-ucan"
 
 export const raw = RAW.code
 
@@ -99,9 +99,8 @@ export const link = async (ucan, options) => {
 
 /**
  * @template {UCAN.Capability} C
- * @template {UCAN.UCAN<C>} Data
  * @template {number} [A=typeof sha256.code]
- * @param {Data} ucan
+ * @param {UCAN.UCAN<C>} ucan
  * @param {{hasher?: UCAN.MultihashHasher<A>}} [options]
  */
 export const write = async (
@@ -109,7 +108,7 @@ export const write = async (
   { hasher = /** @type {UCAN.MultihashHasher<any> } */ (sha256) } = {}
 ) => {
   const bytes = encode(ucan)
-  const cid = /** @type {CID & UCAN.Link<Data, 1, Data['code'], A>} */ (
+  const cid = /** @type {CID & UCAN.Proof<C, A>} */ (
     CID.createV1(ucan.code, await hasher.digest(bytes))
   )
   return { cid, bytes }

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -83,6 +83,15 @@ export type Proof<C extends Capability = Capability> =
   | Link<Data<C>, 1, typeof code>
   | Link<JWT<Data<C>>, 1, typeof RAW_CODE>
 
+export interface Block<
+  T extends unknown = unknown,
+  C extends number = number,
+  A extends number = number
+> {
+  bytes: ByteView<T>
+  cid: Link<T, 1, C, A>
+}
+
 export type Ability = `${string}/${string}` | "*"
 export type Resource = `${string}:${string}`
 

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -79,9 +79,10 @@ export interface UCANOptions<
   proofs?: Array<Proof>
 }
 
-export type Proof<C extends Capability = Capability> =
-  | Link<Data<C>, 1, typeof code>
-  | Link<JWT<Data<C>>, 1, typeof RAW_CODE>
+export type Proof<
+  C extends Capability = Capability,
+  A extends number = number
+> = Link<Data<C>, 1, typeof code, A> | Link<JWT<Data<C>>, 1, typeof RAW_CODE, A>
 
 export interface Block<
   T extends unknown = unknown,


### PR DESCRIPTION
I find myself encoding block and creating CID for it very often. To make this case simple I have added `write` API that returns `Block` object that car library expects. 