### PR TITLE
chore: remove obsolete defs

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,7 +1,9 @@
+import type { ByteView } from "./marker.js"
+
 /**
  * Represents an entity that can verify signatures produced by a given signing algorithm `A`.
- * 
- * @template A - the [multicodec code](https://github.com/multiformats/multicodec/blob/master/table.csv) 
+ *
+ * @template A - the [multicodec code](https://github.com/multiformats/multicodec/blob/master/table.csv)
  * for a cryptographic signing algorithm
  */
 export interface Verifier<A extends number = number> {
@@ -13,9 +15,9 @@ export interface Verifier<A extends number = number> {
 }
 
 /**
- * Represents an entity that can sign a payload using the signing algorithm `A`. 
- * 
- * @template A - the [multicodec code](https://github.com/multiformats/multicodec/blob/master/table.csv) 
+ * Represents an entity that can sign a payload using the signing algorithm `A`.
+ *
+ * @template A - the [multicodec code](https://github.com/multiformats/multicodec/blob/master/table.csv)
  * for a cryptographic signing algorithm
  */
 export interface Signer<A extends number = number> {
@@ -27,9 +29,9 @@ export interface Signer<A extends number = number> {
 
 /**
  * Represents a cryptographic signature of (the byte-encoding of) some data of type `T`.
- * 
+ *
  * @template T - represents the structure of the data that was byte-encoded before signing
- * @template A - the [multicodec code](https://github.com/multiformats/multicodec/blob/master/table.csv) 
+ * @template A - the [multicodec code](https://github.com/multiformats/multicodec/blob/master/table.csv)
  * for a cryptographic signing algorithm
  */
 export interface Signature<T = unknown, A extends number = number>
@@ -69,38 +71,6 @@ export interface AsyncSigner<A extends number = number> {
 }
 
 /**
- * A byte-encoded representation of some type of `Data`. 
- * 
- * A `ByteView` is essentially a `Uint8Array` that's been "tagged" with
- * a `Data` type parameter indicating the type of encoded data.
- * 
- * For example, a `ByteView<DID>` is a `Uint8Array` containing a binary
- * representation of a {@link DID}.
- */
-export interface ByteView<Data> extends Uint8Array, Phantom<Data> {}
-
-/**
  * Something you can `await` and get a `T` out of. Either a `T` already, or a Promise for a `T`.
  */
 export type Await<T> = T | PromiseLike<T>
-
-/**
- * A utility type to retain an unused type parameter `T`.
- * Similar to [phantom type parameters in Rust](https://doc.rust-lang.org/rust-by-example/generics/phantom.html).
- * 
- * Capturing unused type parameters allows us to define "nominal types," which
- * TypeScript does not natively support. Nominal types in turn allow us to capture
- * semantics not represented in the actual type structure, without requring us to define
- * new classes or pay additional runtime costs.
- * 
- * For a concrete example, see {@link ByteView}, which extends the `Uint8Array` type to capture
- * type information about the structure of the data encoded into the array.
- */
-export interface Phantom<T> {
-  // This field can not be represented because field name is non-existings
-  // unique symbol. But given that field is optional any object will valid
-  // type contstraint.
-  [PhantomKey]?: T
-}
-
-declare const PhantomKey: unique symbol

--- a/src/lib.js
+++ b/src/lib.js
@@ -159,8 +159,8 @@ export const issue = async ({
     signature: EMPTY,
   })
 
-  const payload = UTF8.encode(Formatter.formatPayload(data))
-  /** @type {UCAN.Signature<C>} */
+  const payload = UTF8.encode(Formatter.formatSignPayload(data))
+
   const signature = await issuer.sign(payload)
 
   return View.cbor({ ...data, signature })
@@ -175,7 +175,10 @@ export const issue = async ({
  */
 export const verifySignature = (ucan, authority) =>
   formatDID(ucan.issuer) === authority.did() &&
-  authority.verify(UTF8.encode(Formatter.formatPayload(ucan)), ucan.signature)
+  authority.verify(
+    UTF8.encode(Formatter.formatSignPayload(ucan)),
+    ucan.signature
+  )
 
 /**
  * Check if a UCAN is expired.

--- a/src/marker.ts
+++ b/src/marker.ts
@@ -1,0 +1,60 @@
+/**
+ * A byte-encoded representation of some type of `Data`.
+ *
+ * A `ByteView` is essentially a `Uint8Array` that's been "tagged" with
+ * a `Data` type parameter indicating the type of encoded data.
+ *
+ * For example, a `ByteView<DID>` is a `Uint8Array` containing a binary
+ * representation of a {@link DID}.
+ */
+export interface ByteView<Data> extends Uint8Array, Phantom<Data> {}
+
+/**
+ * Utility type that retains type information about data of type `In`, encoded
+ * as type `Out`.
+ *
+ * For concrete examples see {@link ToString} and {@link ToJSONString}.
+ */
+export type Encoded<In, Out> = Out & Phantom<In>
+
+/**
+ * Data of some type `In`, encoded as a string.
+ */
+export type ToString<In, Out extends string = string> = Encoded<In, Out>
+
+/**
+ * Data of some type `In`, encoded as a JSON string.
+ */
+export type ToJSONString<In, Out extends string = string> = Encoded<In, Out>
+
+/**
+ * A byte-encoded representation of some type of `Data`.
+ *
+ * A `ByteView` is essentially a `Uint8Array` that's been "tagged" with
+ * a `Data` type parameter indicating the type of encoded data.
+ *
+ * For example, a `ByteView<DID>` is a `Uint8Array` containing a binary
+ * representation of a {@link DID}.
+ */
+export interface ByteView<Data> extends Uint8Array, Phantom<Data> {}
+
+/**
+ * A utility type to retain an unused type parameter `T`.
+ * Similar to [phantom type parameters in Rust](https://doc.rust-lang.org/rust-by-example/generics/phantom.html).
+ *
+ * Capturing unused type parameters allows us to define "nominal types," which
+ * TypeScript does not natively support. Nominal types in turn allow us to capture
+ * semantics not represented in the actual type structure, without requring us to define
+ * new classes or pay additional runtime costs.
+ *
+ * For a concrete example, see {@link ByteView}, which extends the `Uint8Array` type to capture
+ * type information about the structure of the data encoded into the array.
+ */
+export interface Phantom<T> {
+  // This field can not be represented because field name is non-existings
+  // unique symbol. But given that field is optional any object will valid
+  // type contstraint.
+  [Marker]?: T
+}
+
+declare const Marker: unique symbol

--- a/src/parser.js
+++ b/src/parser.js
@@ -16,7 +16,7 @@ import * as raw from "multiformats/codecs/raw"
  */
 export const parse = input => {
   const segments = input.split(".")
-  const [header, body, signature] =
+  const [header, payload, signature] =
     segments.length === 3
       ? segments
       : ParseError.throw(
@@ -25,7 +25,7 @@ export const parse = input => {
 
   return {
     ...parseHeader(header),
-    ...parseBody(body),
+    ...parsePayload(payload),
     signature: base64urlpad.baseDecode(signature),
   }
 }
@@ -48,19 +48,19 @@ export const parseHeader = header => {
  * @template {UCAN.Capability} C
  * @param {string} input
  */
-export const parseBody = input => {
+export const parsePayload = input => {
   /** @type {UCAN.Payload<C>} */
-  const body = json.decode(base64urlpad.baseDecode(input))
+  const payload = json.decode(base64urlpad.baseDecode(input))
 
   return {
-    issuer: parseDID(body.iss, "iss"),
-    audience: parseDID(body.aud, "aud"),
-    expiration: parseInt(body.exp, "exp"),
-    nonce: parseOptionalString(body.nnc, "nnc"),
-    notBefore: parseOptionalInt(body.nbf, "nbf"),
-    facts: parseOptionalArray(body.fct, parseFact, "fct") || [],
-    proofs: parseProofs(body.prf, "prf"),
-    capabilities: /** @type {C[]} */ (parseCapabilities(body.att, "att")),
+    issuer: parseDID(payload.iss, "iss"),
+    audience: parseDID(payload.aud, "aud"),
+    expiration: parseInt(payload.exp, "exp"),
+    nonce: parseOptionalString(payload.nnc, "nnc"),
+    notBefore: parseOptionalInt(payload.nbf, "nbf"),
+    facts: parseOptionalArray(payload.fct, parseFact, "fct") || [],
+    proofs: parseProofs(payload.prf, "prf"),
+    capabilities: /** @type {C[]} */ (parseCapabilities(payload.att, "att")),
   }
 }
 


### PR DESCRIPTION
- consolidates duplicate type defs into `marker.ts`
- remove obsolote `Head` type.