### PR TITLE
feat: extend capability type

### DIFF
--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -200,10 +200,16 @@ export type Resource = `${string}:${string}`
 export interface Capability<
   Can extends Ability = Ability,
   With extends Resource = Resource
-> {
+> extends Record<string, unknown> {
   with: With
   can: Can
 }
+
+/**
+ * Utility type for capturing capability constraints that is fields other than
+ * "can" and "with".
+ */
+export type Constraints<C extends Capability> = Omit<C, "can" | "with">
 
 /**
  * A string-endcoded decentralized identity document (DID).


### PR DESCRIPTION
Changes `Capability` type so other fields are defined as unknown. This greatly improves validator code as it can access arbitrary fields this way.