### PR TITLE
fix: type errors

### DIFF
--- a/src/codec/cbor.js
+++ b/src/codec/cbor.js
@@ -92,6 +92,7 @@ export { format }
  * @extends {View<C>}
  */
 class CBORView extends View {
+  /** @type {UCAN.MulticodecCode<typeof code, "CBOR">} */
   get code() {
     return code
   }

--- a/src/codec/jwt.js
+++ b/src/codec/jwt.js
@@ -62,6 +62,7 @@ class JWTView extends View {
     super(model)
     this.model = model
   }
+  /** @type {UCAN.MulticodecCode<typeof code, "Raw">} */
   get code() {
     return code
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -77,8 +77,8 @@ export const link = async (ucan, options) => {
  */
 export const write = async (ucan, { hasher = defaultHasher } = {}) => {
   const [code, bytes] = ucan.jwt
-    ? [JWT.code, JWT.encode(ucan)]
-    : [CBOR.code, CBOR.encode(ucan)]
+    ? [/** @type {UCAN.Code} */ (JWT.code), JWT.encode(ucan)]
+    : [/** @type {UCAN.Code} */ (CBOR.code), CBOR.encode(ucan)]
   const digest = await hasher.digest(bytes)
 
   return {

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -1161,6 +1161,7 @@ describe("ts-ucan compat", () => {
 describe("api compatibility", () => {
   it("multiformats compatibility", async () => {
     const Block = await import("multiformats/block")
+    /** @type {UCAN.Model} */
     const ucan = await UCAN.issue({
       issuer: alice,
       audience: DID.parse(bob.did()),


### PR DESCRIPTION
I didn't notice, but https://github.com/ipld/js-dag-ucan/pull/97 did not run tests so the type errors were not seen. This PR fixes the errors.