### PR TITLE
`SignatureView["verify"]` takes any `ByteView`

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -59,7 +59,7 @@ export interface SignatureView<T = unknown, Alg extends SigAlg = SigAlg>
    */
   verify: (
     signer: Verifier<Alg>,
-    payload: ByteView<T>
+    payload: ByteView<unknown>
   ) => Await<{ ok: {}; error?: undefined } | { error: Error; ok?: undefined }>
 }
 


### PR DESCRIPTION
## Rationale

`SignatureView["verify"]` can always take *any* `ByteView`—meaning it won't misbehave or throw an error. Presumably, it will only *succeed* if the types match (along with the actual data), but you're allowed to call `verify()` when it might fail. In fact, that's its whole purpose. 🙂

Before this change, `SignatureView` is contravariant in its type parameter `T`. This means that a `SignatureView` of a more specific type, like `SignatureView<string>`, cannot be assigned where a `SignatureView` of a broader type is expected, like `SignatureView<unknown>`. The reasoning from TypeScript's perspective makes sense: `SignatureView<unknown>`'s `verify()` can be called with any `ByteView`, but `SignatureView<string>`'s `verify()` can *only* be called with a `ByteView<string>`. If you assign a `SignatureView<string>` to a `SignatureView<unknown>` location, the code will no longer know to call `verify()` on it only with a `ByteView<string>`. It would appear perfectly valid to TypeScript to call it with a `ByteView<number>`, for instance, which is supposed to be invalid.

But actually, calling it with a `ByteView<number>` would be fine, it would just (presumably) return an `{ error: ... }` object to signal that the signature doesn't verify.

[Playground Example](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgQQO4ENgwDRwEICeMApgGrDGq4DKwA5sgDZ030B26MArlMa3R269ylXAGEoBMDAhwAvnABmUCCDgByAALAwjACYB6PejoBaLgGN0bdQChbBg3AAKKyAGdieuBYAW1ui84ADdiKHdgCDY4CEU4WgFOHjIKVFtiAA9IWDhgNhIoRXQLYnj2JOFUgCYAHgAVOABeOC42AGs2CFQ2XCY6OEySNj13MoZmJrG+gD5bOAGMoZGxwWT63uZpxDm4AwAqPZ24PbhSMOBFClGYf3gb0ojEoVKMUbAVPUsggCMCOHu4HRgKFospVP9fKUgSCjicwOgCIwIOg9AA6WEGHahKAXAgALjgAAojnBHmwwgSJFIZKizjjLmEajNsCT4YjkXoCYQSCJUDVWh0umxZvN5o5RRLJRKAHqyuXSnYASiaWzQmBgNSQEDaBIQcgA3AMoCooAB+AmtPTES7k7wKAA+iCNJoJAFFjdBDdrzS1hta8kE5LM5PZHI57FaLIx0LwfFF3PBSK6AEoASQAYqmU5TJNIILTzgyoPrbJHo7GLPH4AARZB1ZAEgCqeRgAA5kMaESWHE48NboMRbJW2An-ug2sQEqtY81CWSKsQCVOF7z+e1Ot1psrGlsEDt589UdjcYSk2nMyncLX64rbCGyzHSsPR48l+VnquEzi2HRZjBx5O77JHO9C3j2KCKAUQ5VmOE7Ls8VSTCBTzJG+KGVJQtQChuwrbru+5AbwR6FgQp4phmWbJledbILe97EFGj5xiO8CPFUaHTikmE1F+eS-rY-5wYRxBVMhVS3kAA)

This becomes an issue, for instance, in Ucanto, where function which takes a `Receipt`, but doesn't care what the type of its `out` value is, can currently *only* take a `Receipt` whose `out` type is exactly as unknown.

[Playground Example](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgJQKYGNXDPAvnAMyghDgHIABAV3QEMA7GCAemEdSgNszIChf0EegGd4MWgGtUaTNngBeOAAooGLDgBcKNXICUceQD5EvOHGbM4AOhu9c-C3AAqAC2DC47uADdaAG2AAEwAaOAAjDFoqYVQ4GBdYgAMIKhhEuIBPMFivVAAPbhg-DLiEuGFaEFQbK15AjD9aVThBEXgGDIB5MIArDBgZdRgtQblecSlRnCUO7r70AZ0cXQdLGrDU0q9hFxS-QPDY3wCDpgha+vRG5tbRcpgoNgBzKeHtWRwAHlFH+ifDcaSaRLGBKH7PV4rIA)